### PR TITLE
Fix reviews header typo

### DIFF
--- a/app/reviews/page.tsx
+++ b/app/reviews/page.tsx
@@ -10,7 +10,7 @@ export default function Reviews() {
 
   return (
     <FrontOfficePage breadcrumbs={breadcrumbItems} title="Recensioni">
-      <Typography variant="h4">Tabbella movies recensioni</Typography>
+      <Typography variant="h4">Tabella movies recensioni</Typography>
     </FrontOfficePage>
   );
 }


### PR DESCRIPTION
## Summary
- correct "Tabbella" to "Tabella" in reviews page header

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684847e01a888332b76c2cc4da27ddc4