### PR TITLE
Switch movie list generics to IMovie

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import { ROOT } from "@/routes";
 import { moviesColumns } from "./columns";
 import { useTable } from "@/hooks";
 import { useEffect, useState } from "react";
-import { getMoviesList, IMovieDto } from "@/services";
+import { getMoviesList, IMovie } from "@/services";
 import { IPaginatedList } from "@/utils";
 import { useTheme } from "@mui/material";
 import { useRouter } from "next/navigation";
@@ -17,7 +17,7 @@ export default function Movies() {
 
   const { tableProps, tableState } = useTable();
 
-  const [movies, setMovies] = useState<IPaginatedList<IMovieDto>>();
+  const [movies, setMovies] = useState<IPaginatedList<IMovie>>();
 
   useEffect(() => {
     const fetchMovies = async () => {

--- a/services/api/movies/movies.ts
+++ b/services/api/movies/movies.ts
@@ -1,12 +1,12 @@
 // api/tmdb.ts
 import { API, IPaginatedList, obj2qstring, QueryParamsObj } from "@/utils";
-import { IMovieDto } from "./movies.types";
+import { IMovie } from "./movies.types";
 
 /**
  * Ottiene la lista di film con paginazione e supporto per `pageSize` personalizzato.
  * TMDB supporta massimo 20 film per pagina, quindi per `pageSize > 20` bisogna fare più richieste.
  */
-export const getMoviesList = async (params: QueryParamsObj): Promise<IPaginatedList<IMovieDto>> => {
+export const getMoviesList = async (params: QueryParamsObj): Promise<IPaginatedList<IMovie>> => {
   const page = params.page || 1;
   const pageSize = params.pageSize || 5; // Default 10
   const moviesPerRequest = 20; // TMDB restituisce sempre 20 film per pagina
@@ -14,13 +14,13 @@ export const getMoviesList = async (params: QueryParamsObj): Promise<IPaginatedL
   // Quante pagine dobbiamo chiamare per ottenere abbastanza risultati?
   const pagesToFetch = Math.ceil(pageSize / moviesPerRequest);
 
-  let allResults: IMovieDto[] = [];
+  let allResults: IMovie[] = [];
 
   for (let i = 0; i < pagesToFetch; i++) {
     const queryParams = obj2qstring({ page: page + i });
     const res = await API.get<{
       page: number;
-      results: IMovieDto[];
+      results: IMovie[];
       total_pages: number;
       total_results: number;
     }>(`/movie/popular${queryParams}`);


### PR DESCRIPTION
## Summary
- fix API helper typings for movie list
- update usage of movie list in `page.tsx`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848481302088332b259f134757072f2